### PR TITLE
Add mock xcodeproj to support autolinking

### DIFF
--- a/ios/flipper-plugin-react-native-performance.xcodeproj/project.pbxproj
+++ b/ios/flipper-plugin-react-native-performance.xcodeproj/project.pbxproj
@@ -1,0 +1,369 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		93B250D7256EA0A6007CC95B /* FlipperReactPerformancePlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = 93B250D5256EA0A6007CC95B /* FlipperReactPerformancePlugin.m */; };
+		93B250D8256EA0A6007CC95B /* FlipperReactPerformancePlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B250D6256EA0A6007CC95B /* FlipperReactPerformancePlugin.h */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		5D82366D1B0CE05B005A9EF3 /* Copy Headers */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			name = "Copy Headers";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6478985D1F38BF9100DA1C12 /* Copy Headers */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			name = "Copy Headers";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		5D82366F1B0CE05B005A9EF3 /* libflipper-plugin-react-native-performance.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libflipper-plugin-react-native-performance.a"; path = "/Users/joel.arvidsson/Code/flipper-plugin-react-native-performance/examples/Vanilla/node_modules/flipper-plugin-react-native-performance/ios/build/Debug-iphoneos/libflipper-plugin-react-native-performance.a"; sourceTree = "<absolute>"; };
+		6478985F1F38BF9100DA1C12 /* libRNKeychain.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libRNKeychain.a; path = "/Users/joel.arvidsson/Code/flipper-plugin-react-native-performance/examples/Vanilla/node_modules/flipper-plugin-react-native-performance/ios/build/Debug-appletvos/libRNKeychain.a"; sourceTree = "<absolute>"; };
+		93B250D5256EA0A6007CC95B /* FlipperReactPerformancePlugin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FlipperReactPerformancePlugin.m; sourceTree = "<group>"; };
+		93B250D6256EA0A6007CC95B /* FlipperReactPerformancePlugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlipperReactPerformancePlugin.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5D82366C1B0CE05B005A9EF3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6478985C1F38BF9100DA1C12 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		5D8236661B0CE05B005A9EF3 = {
+			isa = PBXGroup;
+			children = (
+				93B250D4256EA09C007CC95B /* FlipperReactPerformancePlugin */,
+			);
+			sourceTree = "<group>";
+			wrapsLines = 0;
+		};
+		93B250D4256EA09C007CC95B /* FlipperReactPerformancePlugin */ = {
+			isa = PBXGroup;
+			children = (
+				93B250D6256EA0A6007CC95B /* FlipperReactPerformancePlugin.h */,
+				93B250D5256EA0A6007CC95B /* FlipperReactPerformancePlugin.m */,
+			);
+			name = FlipperReactPerformancePlugin;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		5DE632D820434281004F9598 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				93B250D8256EA0A6007CC95B /* FlipperReactPerformancePlugin.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5DE632DD204342BC004F9598 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		5D82366E1B0CE05B005A9EF3 /* flipper-plugin-react-native-performance */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5D8236831B0CE05B005A9EF3 /* Build configuration list for PBXNativeTarget "flipper-plugin-react-native-performance" */;
+			buildPhases = (
+				5D82366B1B0CE05B005A9EF3 /* Sources */,
+				5D82366C1B0CE05B005A9EF3 /* Frameworks */,
+				5DE632D820434281004F9598 /* Headers */,
+				5D82366D1B0CE05B005A9EF3 /* Copy Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "flipper-plugin-react-native-performance";
+			productName = RNKeychain;
+			productReference = 5D82366F1B0CE05B005A9EF3 /* libflipper-plugin-react-native-performance.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		6478985E1F38BF9100DA1C12 /* flipper-plugin-react-native-performance-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 647898671F38BF9100DA1C12 /* Build configuration list for PBXNativeTarget "flipper-plugin-react-native-performance-tvOS" */;
+			buildPhases = (
+				6478985B1F38BF9100DA1C12 /* Sources */,
+				6478985C1F38BF9100DA1C12 /* Frameworks */,
+				5DE632DD204342BC004F9598 /* Headers */,
+				6478985D1F38BF9100DA1C12 /* Copy Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "flipper-plugin-react-native-performance-tvOS";
+			productName = "RNKeychain-tvOS";
+			productReference = 6478985F1F38BF9100DA1C12 /* libRNKeychain.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		5D8236671B0CE05B005A9EF3 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0630;
+				ORGANIZATIONNAME = "Joel Arvidsson";
+				TargetAttributes = {
+					5D82366E1B0CE05B005A9EF3 = {
+						CreatedOnToolsVersion = 6.3.1;
+					};
+					6478985E1F38BF9100DA1C12 = {
+						CreatedOnToolsVersion = 8.3.3;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 5D82366A1B0CE05B005A9EF3 /* Build configuration list for PBXProject "flipper-plugin-react-native-performance" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				English,
+				en,
+			);
+			mainGroup = 5D8236661B0CE05B005A9EF3;
+			productRefGroup = 5D8236661B0CE05B005A9EF3;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5D82366E1B0CE05B005A9EF3 /* flipper-plugin-react-native-performance */,
+				6478985E1F38BF9100DA1C12 /* flipper-plugin-react-native-performance-tvOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5D82366B1B0CE05B005A9EF3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				93B250D7256EA0A6007CC95B /* FlipperReactPerformancePlugin.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6478985B1F38BF9100DA1C12 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		5D8236811B0CE05B005A9EF3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		5D8236821B0CE05B005A9EF3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		5D8236841B0CE05B005A9EF3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/node_modules/react-native/React/**",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		5D8236851B0CE05B005A9EF3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/node_modules/react-native/React/**",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		647898651F38BF9100DA1C12 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = RNKeychain;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 10.2;
+			};
+			name = Debug;
+		};
+		647898661F38BF9100DA1C12 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = RNKeychain;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 10.2;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5D82366A1B0CE05B005A9EF3 /* Build configuration list for PBXProject "flipper-plugin-react-native-performance" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5D8236811B0CE05B005A9EF3 /* Debug */,
+				5D8236821B0CE05B005A9EF3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5D8236831B0CE05B005A9EF3 /* Build configuration list for PBXNativeTarget "flipper-plugin-react-native-performance" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5D8236841B0CE05B005A9EF3 /* Debug */,
+				5D8236851B0CE05B005A9EF3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		647898671F38BF9100DA1C12 /* Build configuration list for PBXNativeTarget "flipper-plugin-react-native-performance-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				647898651F38BF9100DA1C12 /* Debug */,
+				647898661F38BF9100DA1C12 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 5D8236671B0CE05B005A9EF3 /* Project object */;
+}


### PR DESCRIPTION
Couldn't get the autolinker to detect the package without this, even if I place a `react-native.config.js` file. The file isn't used AFAICT, and it's historically only needed for linking without cocoapods which also isn't a thing anymore. 